### PR TITLE
tentative fix for #208

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ build/
 dist/
 target/
 nbproject/
+.idea
+*.iml
 nb-configuration.xml
 maven.properties
 github-user.properties


### PR DESCRIPTION
Since we have a max thread count of 10 this appears to be causing some problems with the update repositories method
For now just catch the exception and continue on, if this fixes the problem we can look into a elegant solution